### PR TITLE
Update links to avoid permanent redirects (301)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -245,7 +245,7 @@ initiateMultiScreenExperienceButton.addEventListener('click', async () => {
 # Concepts # {#concepts}
 <!-- ====================================================================== -->
 
-Concepts in this specification build upon those in the [CSSOM-View-1 Working Draft](https://www.w3.org/TR/cssom-view-1), and the [CSSOM-View-1 Editor's Draft](https://drafts.csswg.org/cssom-view/), [[HTML]], and [[Fullscreen]].
+Concepts in this specification build upon those in the [CSSOM-View-1 Working Draft](https://www.w3.org/TR/cssom-view-1/), and the [CSSOM-View-1 Editor's Draft](https://drafts.csswg.org/cssom-view/), [[HTML]], and [[Fullscreen]].
 
 <!-- ====================================================================== -->
 ## Screen ## {#concept-screen}
@@ -849,4 +849,4 @@ Victor Costan
 
 Issue: Ensure we didn't forget anyone!
 
-Special thanks to Tab Atkins, Jr. for creating and maintaining [Bikeshed](https://github.com/tabatkins/bikeshed), the specification authoring tool used to create this document, and for his general authoring advice.
+Special thanks to Tab Atkins, Jr. for creating and maintaining [Bikeshed](https://github.com/speced/bikeshed), the specification authoring tool used to create this document, and for his general authoring advice.


### PR DESCRIPTION
This adjusts two links to avoid permanent redirects:
- Bikeshed's source and documentation were moved to the `speced` organization
- There was a missing trailing slash in the link to CSSOM View 1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/window-management/pull/132.html" title="Last updated on Mar 28, 2023, 9:49 AM UTC (047e223)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/window-management/132/0d4be26...047e223.html" title="Last updated on Mar 28, 2023, 9:49 AM UTC (047e223)">Diff</a>