### PR TITLE
Propagate spec's title change to documentation

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -1,4 +1,4 @@
-# Multi-Screen Window Placement on the Web
+# Window Management on the Web
 
 ## Introduction
 
@@ -86,7 +86,7 @@ See explorations of alternative and supplemental proposals in
 
 ## Support requests to show elements fullscreen on a specific screen
 
-One of the primary use cases for Window Placement is showing fullscreen content
+One of the primary use cases for Window Management is showing fullscreen content
 on the optimal screen for the given use case. An example of this is presenting a
 slideshow or other media on an external display when the web application window
 controlling the presentation is on the 'internal' display built into a laptop.
@@ -554,7 +554,7 @@ navigator.permissions.query({name:'window-management'}).then(function(status) {
 });
 ```
 
-Window Placement is also a
+Window Management is also a
 [policy-controlled feature](https://w3c.github.io/webappsec-permissions-policy/)
 which is disabled by default for embedded cross-origin pages.
 If a cross-origin page wants an embedded page to have access to this API,

--- a/EXPLAINER_initiating_multi_screen_experiences.md
+++ b/EXPLAINER_initiating_multi_screen_experiences.md
@@ -136,7 +136,7 @@ fullscreen request is made that targets a specific screen of a multi-screen
 device, checked and consumed in the rules for choosing a browsing context, when
 the document requests openining a new popup window.
 
-The Multi-Screen Window Placement Working Draft Spec incorporates these changes:
+The Window Management Working Draft Spec incorporates these changes:
 - [Usage Overview: 1.2.6. Initiate multi-screen experiences](https://www.w3.org/TR/window-management/#usage-overview-initiate-multi-screen-experiences)
 - [3.2.3. Window.open() method definition changes](https://www.w3.org/TR/window-management/#api-window-open-method-definition-changes)
 - [3.5.1. Element.requestFullscreen() method definition changes](https://www.w3.org/TR/window-management/#api-element-requestfullscreen-method-definition-changes)
@@ -163,7 +163,7 @@ signal, and the user agent’s configuration.
 
 ## Security Considerations
 
-This feature enables sites to perform two facets of the Multi-Screen Window Placement API with a single user activation; i.e. [`1.2.4. Place fullscreen content on a specific screen`](https://www.w3.org/TR/window-management/#usage-overview-place-fullscreen-content-on-a-specific-screen) and [`1.2.5. Place windows on a specific screen`](https://www.w3.org/TR/window-management/#usage-overview-place-windows-on-a-specific-screen) are combined to [`1.2.6. Initiate multi-screen experiences`](https://www.w3.org/TR/window-management/#usage-overview-initiate-multi-screen-experiences). This may exacerbate some documented Multi-Screen Window Placement [Security Considerations](https://www.w3.org/TR/window-management/#security).
+This feature enables sites to perform two facets of the Window Management API with a single user activation; i.e. [`1.2.4. Place fullscreen content on a specific screen`](https://www.w3.org/TR/window-management/#usage-overview-place-fullscreen-content-on-a-specific-screen) and [`1.2.5. Place windows on a specific screen`](https://www.w3.org/TR/window-management/#usage-overview-place-windows-on-a-specific-screen) are combined to [`1.2.6. Initiate multi-screen experiences`](https://www.w3.org/TR/window-management/#usage-overview-initiate-multi-screen-experiences). This may exacerbate some documented Window Management [Security Considerations](https://www.w3.org/TR/window-management/#security).
 
 A notable security consideration is the placement of the popup window in front of, or behind, the fullscreen window, which could be abused by malicious sites to place content in a deceptive or surreptitious fashion. This was a foremost consideration during development of the current [proposal](https://github.com/w3c/window-management/blob/main/EXPLAINER_initiating_multi_screen_experiences.md#proposal), which documents the inherent and added mitigations against accidental misuse or abuse.
 
@@ -173,7 +173,7 @@ User agents already offer controls to permit any number of script-initiated popu
 
 ## Privacy Considerations
 
-This feature does not expose any information to sites, and there are no privacy considerations to note beyond those already documented in the Multi-Screen Window Placement [Privacy Considerations](https://www.w3.org/TR/window-management/#privacy) section.
+This feature does not expose any information to sites, and there are no privacy considerations to note beyond those already documented in the Window Management [Privacy Considerations](https://www.w3.org/TR/window-management/#privacy) section.
 
 ## Alternatives Considered
 

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,8 +1,8 @@
-# How to use the Multi-Screen Window Placement API
+# How to use the Window Management API
 
-The Multi-Screen Window Placement API is currently available in Chrome:
-- Chrome 100+ enables Multi-Screen Window Placement APIs by default.
-- Chrome 93+ supports Multi-Screen Window Placement APIs with either one of these flags enabled:
+The Window Management API is currently available in Chrome:
+- Chrome 100+ enables Window Management APIs by default.
+- Chrome 93+ supports Window Management APIs with either one of these flags enabled:
   - chrome://flags#enable-experimental-web-platform-features
   - `chrome --enable-blink-features=WindowPlacement`
 
@@ -16,7 +16,7 @@ Here is an example of how to use the API:
 async function main() {
   // Run feature detection.
   if (!('getScreenDetails' in window)) {
-    console.log('The Multi-Screen Window Placement API is not supported.');
+    console.log('The Window Manamgenet API is not supported.');
     return;
   }
   // Detect the presence of extended screen areas.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 <img src="https://w3c.github.io/window-management/logo.svg" height=100 align=right>
 
-# Multi-Screen Window Placement on the Web
+# Window Management on the Web
 
-This repository considers web platform functionality for multi-screen devices.
-The goals here are to explore background, use cases, and proposals for extending
-window placement capabilities of web applications on multi-screen devices.
+This repository considers web platform functionality to allow scripts to query
+the device for information about its screens, and place content on specific
+screens. The goals here are to explore background, use cases, and proposals for
+extending window placement capabilities of web applications on multi-screen
+devices.
 
 See the [Editor’s Draft](https://w3c.github.io/window-management/) of the proposed specification.
 The [Explainer](https://github.com/w3c/window-management/blob/main/EXPLAINER.md),

--- a/mdn-drafts/ScreenDetailed.md
+++ b/mdn-drafts/ScreenDetailed.md
@@ -8,7 +8,7 @@ browser_compatibility: api.ScreenDetailed
 
 ## Description
 
-The `ScreenDetailed` interface of the Window Placement API extends the
+The `ScreenDetailed` interface of the Window Management API extends the
 `Screen` interface and provides additional per-screen information.
 
 The `ScreenDetailed` interface is a child of `Screen` and inherits its members.

--- a/mdn-drafts/ScreenDetails.md
+++ b/mdn-drafts/ScreenDetails.md
@@ -8,7 +8,7 @@ browser_compatibility: api.ScreenDetails
 
 ## Description
 
-The `ScreenDetails` interface of the Window Placement API provides multi-screen information and change events.
+The `ScreenDetails` interface of the Window Management API provides multi-screen information and change events.
 
 ## Constructor
 

--- a/security_and_privacy_initiating_multi_screen_experiences.md
+++ b/security_and_privacy_initiating_multi_screen_experiences.md
@@ -7,7 +7,7 @@ The answers pertain to the [Initiating Multi-Screen Experiences](https://github.
 [Security Considerations](https://github.com/w3c/window-management/blob/main/EXPLAINER_initiating_multi_screen_experiences.md#security-considerations) and 
 [Privacy Considerations](https://github.com/w3c/window-management/blob/main/EXPLAINER_initiating_multi_screen_experiences.md#privacy-considerations) sections.
 
-See [security_and_privacy.md](https://github.com/w3c/window-management/blob/main/security_and_privacy.md) for answers pertaining to the underlying [Multi-Screen Window Placement API](https://www.w3.org/TR/window-management/).
+See [security_and_privacy.md](https://github.com/w3c/window-management/blob/main/security_and_privacy.md) for answers pertaining to the underlying [Window Management API](https://www.w3.org/TR/window-management/).
 
 ## 2.1 What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary?
 This feature enhancement does not expose any additional information; see the base API's [corresponding answer](https://github.com/w3c/window-management/blob/main/security_and_privacy.md#21-what-information-might-this-feature-expose-to-web-sites-or-other-parties-and-for-what-purposes-is-that-exposure-necessary).


### PR DESCRIPTION
This updates occurrences of "Multi-Screen Window Placement" to rather use the new "Window Management" title through the repository's content, except in cases where the document actually describes the change of name.