### PR TITLE
Add message about obsolescence to fullscreen popup content

### DIFF
--- a/EXPLAINER_fullscreen_popups.md
+++ b/EXPLAINER_fullscreen_popups.md
@@ -1,3 +1,11 @@
+
+# 🟥 Obsolete 🟥
+
+This feature is no longer being pursued as of March 27, 2024. This feature is superseded by [HTML Fullscreen Without a Gesture](https://github.com/explainers-by-googlers/html-fullscreen-without-a-gesture) which provides similar capabilities. The document below is maintained for archival reasons.
+
+---
+
+
 # Window Management on the Web - Creating Fullscreen Popup Windows
 
 ## Introduction

--- a/security_and_privacy_fullscreen_popups.md
+++ b/security_and_privacy_fullscreen_popups.md
@@ -1,3 +1,8 @@
+
+# 🟥 Obsolete 🟥
+
+This feature is no longer being pursued as of March 27, 2024. See [explainer](EXPLAINER_fullscreen_popups.md#obsolete).
+
 # Security & Privacy
 
 The following considerations are taken from the [W3C Security and Privacy


### PR DESCRIPTION
Adds a header to fullscreen popup explainer and security and private fullscreen popups about obsolescence and link to the new html without a gesture content.